### PR TITLE
Add description about using lldb instead of gdb.

### DIFF
--- a/4_bug.md
+++ b/4_bug.md
@@ -392,6 +392,8 @@ The following code can reproduce this issue:
 
 `test.rb` に `hello(nil)` と記入し、`make gdb` と実行しましょう。
 
+(lldb を用いる場合は、 `make lldb` と実行した後に、 `run` を実行。)
+
 ```
 Program received signal SIGSEGV, Segmentation fault.
 f_hello (self=9904840, name=8) at ../../trunk/io.c:12333


### PR DESCRIPTION
https://github.com/ko1/rubyhackchallenge/blob/master/4_bug.md において `gdp` の代わりに `lldp` を用いる場合のドキュメントを追加しました。

@ko1 