### PR TITLE
Trivial bugfix

### DIFF
--- a/yasm/yasm.rb
+++ b/yasm/yasm.rb
@@ -153,7 +153,7 @@ class YASM
   end
 
   def disasm
-    puts to_iseq.disasm
+    to_iseq.disasm
   end
 
   def eval


### PR DESCRIPTION
* I saw there were some `puts iseq.disasm` calls, which meant
  `puts(puts(to_iseq.disasm))`. I don't think it's intentional.