### PR TITLE
Fix typo of directory name

### DIFF
--- a/EN/2_mri_structure.md
+++ b/EN/2_mri_structure.md
@@ -151,7 +151,7 @@ At a glance, the following directory structure you can observe:
 * `ruby/include/ruby/*`: external definitions. C-extension libraries can use them.
 * `ruby/enc/`: encoding information.
 * `ruby/defs/`: various definitions.
-* `ruby/tools/`: tools to build MRI.
+* `ruby/tool/`: tools to build MRI.
 * `ruby/missing/`: implementations for features that are missing in some OSes
 * `ruby/cygwin/`, `ruby/nacl/`, `ruby/win32`, ...: OS/system dependent code.
 

--- a/JA/2_mri_structure.md
+++ b/JA/2_mri_structure.md
@@ -188,7 +188,7 @@ Ruby のソースコードを修正すると、C プログラムなので容易�
 * `ruby/include/ruby/*`: 外部定義。拡張ライブラリで参照できます
 * `ruby/enc/`: エンコーディングのためのソースコードや情報
 * `ruby/defs/`: 各種定義
-* `ruby/tools/`: MRI をビルド・実行するためのツール
+* `ruby/tool/`: MRI をビルド・実行するためのツール
 * `ruby/missing/`: いくつかの OS で足りないものの実装
 * `ruby/cygwin/`, `ruby/nacl/`, `ruby/win32`, ...: OS/system 依存のソースコード
 


### PR DESCRIPTION
Probably, `tool`?
https://github.com/ruby/ruby/tree/trunk/tool