### PR TITLE
Add description of build failure

### DIFF
--- a/JA/2_mri_structure.md
+++ b/JA/2_mri_structure.md
@@ -83,11 +83,20 @@ $ sudo apt-get install git ruby autoconf bison gcc make zlib1g-dev libffi-dev li
 
 以前にRubyを上記の方法でビルドしたことがある場合、 `make` コマンドが失敗する可能性があります。
 その場合は、
+
 ```
 make clean
+```
+
+を実行して古いファイル・ディレクトリを削除してから再度 `make` コマンドを実行してみてください。
+
+それでも失敗する場合は、
+
+```
 make distclean
 ```
-を実行して古いファイル・ディレクトリを削除してから再度 `make` コマンドを実行してみてください。
+
+でconfigureからやり直すとうまくいく可能性があります。
 
 ## 演習：ビルドした Ruby でプログラムを実行してみよう
 

--- a/JA/2_mri_structure.md
+++ b/JA/2_mri_structure.md
@@ -79,6 +79,16 @@ $ sudo apt-get install git ruby autoconf bison gcc make zlib1g-dev libffi-dev li
 
 なお、この 2 回の `make` については、`make all install` とすると、1回の呼び出しで終わります。
 
+### 久しぶりに実行したビルドでエラーが起こる場合
+
+以前にRubyを上記の方法でビルドしたことがある場合、 `make` コマンドが失敗する可能性があります。
+その場合は、
+```
+make clean
+make distclean
+```
+を実行してから再度 `make` コマンドを実行してみてください。
+
 ## 演習：ビルドした Ruby でプログラムを実行してみよう
 
 ビルドした Ruby で実際に Ruby スクリプトを実行する方法はいくつかあります。

--- a/JA/2_mri_structure.md
+++ b/JA/2_mri_structure.md
@@ -87,7 +87,7 @@ $ sudo apt-get install git ruby autoconf bison gcc make zlib1g-dev libffi-dev li
 make clean
 make distclean
 ```
-を実行してから再度 `make` コマンドを実行してみてください。
+を実行して古いファイル・ディレクトリを削除してから再度 `make` コマンドを実行してみてください。
 
 ## 演習：ビルドした Ruby でプログラムを実行してみよう
 


### PR DESCRIPTION
I stumbled upon the issue where I built Ruby several months ago and the build failed due to old things generated by the old build.
It's resolved by `make clean && make distclean` so I found it helpful for some people.