### PR TITLE
Fix install doc

### DIFF
--- a/EN/2_mri_structure.md
+++ b/EN/2_mri_structure.md
@@ -50,7 +50,7 @@ Due to limited network bandwidth at the venue, please clone the source code at h
 1. Check the required commands described above.
 2. `$ cd workdir/` # Move to `workdir`
 3. `$ cd ruby` # Move to `workdir/ruby`
-4. `$ autoconf`
+4. `$ ./autogen.sh`
 5. `$ cd ..`
 6. `$ mkdir build`
 7. `$ cd build`

--- a/JA/2_mri_structure.md
+++ b/JA/2_mri_structure.md
@@ -46,7 +46,7 @@ $ sudo apt-get install git ruby autoconf bison gcc make zlib1g-dev libffi-dev li
 1. 上記「前提とするコマンド」を確認
 2. `$ cd workdir/` # workdir に移動します
 3. `$ cd ruby` # workdir/ruby に移動します
-4. `$ autoconf`
+4. `$ ./autogen.sh`
 5. `$ cd ..`
 6. `$ mkdir build` # `workdir/build` を作成します
 7. `$ cd build`

--- a/JA/2_mri_structure.md
+++ b/JA/2_mri_structure.md
@@ -67,7 +67,7 @@ $ sudo apt-get install git ruby autoconf bison gcc make zlib1g-dev libffi-dev li
 
 上記手順では、主に次のことをしています。
 
-* `autoconf` による `configure` スクリプトの生成
+* `autoreconf` による `configure` スクリプトの生成
 * `configure` による `Makefile` の生成
 * `make` による `./ruby` の生成（`make` 単体での実行は `make all` の意味になります）。これは、いくつかの生成が含まれています。
   * `make miniruby` による `./miniruby` の生成


### PR DESCRIPTION
Close #78 

Note that I didn't add `automake` to required tools list since in https://bugs.ruby-lang.org/issues/17723#note-5 `automake` seems not not be required. See also: https://github.com/ko1/rubyhackchallenge/issues/78#issuecomment-855232767