### PR TITLE
Add dependency libyaml-dev

### DIFF
--- a/EN/2_mri_structure.md
+++ b/EN/2_mri_structure.md
@@ -32,7 +32,7 @@ Standard Ruby extensions (such as zlib, openssl, etc.) will be built if the libr
 If you use `apt-get` (or `apt`) for package management in your environment, then you can get all dependencies with the following command:
 
 ```
-$ sudo apt-get install git ruby autoconf bison gcc make zlib1g-dev libffi-dev libreadline-dev libgdbm-dev libssl-dev
+$ sudo apt-get install git ruby autoconf bison gcc make zlib1g-dev libffi-dev libreadline-dev libgdbm-dev libssl-dev libyaml-dev
 ```
 
 ## Exercise: Clone the MRI source code

--- a/JA/2_mri_structure.md
+++ b/JA/2_mri_structure.md
@@ -30,7 +30,7 @@ git、ruby、autoconf、bison、gcc (or clang, etc）、make が必須です。�
 `apt-get` が使える環境では、下記のようなコマンドでインストールされます。
 
 ```
-$ sudo apt-get install git ruby autoconf bison gcc make zlib1g-dev libffi-dev libreadline-dev libgdbm-dev libssl-dev
+$ sudo apt-get install git ruby autoconf bison gcc make zlib1g-dev libffi-dev libreadline-dev libgdbm-dev libssl-dev libyaml-dev
 ```
 
 ## 演習: MRI のソースコードを clone


### PR DESCRIPTION
libyaml-dev is no longer bundled.
ref: https://github.com/ruby/psych/pull/541