### PR TITLE
Add an instruction to rebuild ruby command

### DIFF
--- a/EN/3_practice.md
+++ b/EN/3_practice.md
@@ -27,10 +27,12 @@ Steps:
 3. Add the statement `rb_define_method(rb_cArray, "second", ary_second, 0);` to the body of the `Init_Array()` function.
 4. Write some sample code to try your new method in `ruby/test.rb`, then build and run with `make run`.
 5. Add a test in `ruby/test/ruby/test_array.rb`. These tests are written in the minitest format.
-6. `$ make test-all` will run the test code you wrote. However, it runs a tremendous number of ruby tests, so you may want to run only the Array-related tests.
+6. `$ make -j && make install` will rebuild ruby command.
+  * To rebuild ruby command, we need to execute `make install` in addition to `make -j`.
+7. `$ make test-all` will run the test code you wrote. However, it runs a tremendous number of ruby tests, so you may want to run only the Array-related tests.
   * `$ make test-all TESTS='ruby/test_array.rb'` will test only `ruby/test/ruby/test_array.rb`.
   * `$ make test-all TESTS='-j8'` will run in parallel with 8 processes.
-7. Add rdoc documentation of `Array#second` by referencing the documentation of other methods in `array.c`.
+8. Add rdoc documentation of `Array#second` by referencing the documentation of other methods in `array.c`.
 
 
 One possible implementation of `ary_second()` is shown below. Line numbers may differ because `array.c` is likely to have changed since this document was written.

--- a/JA/3_practice.md
+++ b/JA/3_practice.md
@@ -27,11 +27,13 @@ end
 3. `rb_define_method(rb_cArray, "second", ary_second, 0);` という行を `Init_Array()` 関数に追加しましょう。
 4. ビルドし、`ruby/test.rb` にサンプルコードを記述して、`make run` で動くか試してみましょう。
 5. テストを `ruby/test/ruby/test_array.rb` に記入しましょう。minitest フォーマットです。
-6. `$ make test-all` と実行すると、書いたテストが実行されます。ただし、数万のテストが走ってしまうので、Array のテストだけに絞りましょう。
+6. `$ make -j && make install` を実行して ruby コマンドをビルドし直しましょう
+  * ruby コマンドをビルドし直すには `make -j` だけでなく `make install` も実行する必要があります
+7. `$ make test-all` と実行すると、書いたテストが実行されます。ただし、数万のテストが走ってしまうので、Array のテストだけに絞りましょう。
   * `$ make test-all TESTS='ruby/test_array.rb'` とすることで、`ruby/test/ruby/test_array.rb` だけテストします。
   * `$ make test-all TESTS='ruby/test_array.rb -n test_xxx'` とすることで、`ruby/test_array.rb` にある `test_xxx` にマッチするテストのみ走らせます。
   * `$ make test-all TESTS='-j8'` とすることで、8 並列でテストを走らせます。
-7. ほかのメソッドを参考に、`Array#second` に rdoc ドキュメントを記入してみましょう。
+8. ほかのメソッドを参考に、`Array#second` に rdoc ドキュメントを記入してみましょう。
 
 C での定義はこんな感じになります（下記 diff を取ってから時間がたっているので、行番号は、ずれていると思います）。
 


### PR DESCRIPTION
If we follow the current instructions, we get `NoMethodError: undefined method second for [1,2,3]:Array`.
It seems we need to execute `make install` before `make test-all`.

Without `make install`, `build/ruby` are still old even if we execute `make -j`.
I think it's because `build/ruby` loads `install/lib/libruby.3.2.dylib` (in macOS), and `make -j` does not update it.