### PR TITLE
add other install description

### DIFF
--- a/EN/2_mri_structure.md
+++ b/EN/2_mri_structure.md
@@ -35,6 +35,7 @@ If you use `apt-get` (or `apt`) for package management in your environment, then
 $ sudo apt-get install git ruby autoconf bison gcc make zlib1g-dev libffi-dev libreadline-dev libgdbm-dev libssl-dev libyaml-dev
 ```
 
+If you would like to install other than `apt-get`, please refer to [Home · rbenv/ruby\-build Wiki](https://github.com/rbenv/ruby-build/wiki)
 ## Exercise: Clone the MRI source code
 
 Use the following commands:

--- a/EN/2_mri_structure.md
+++ b/EN/2_mri_structure.md
@@ -35,7 +35,7 @@ If you use `apt-get` (or `apt`) for package management in your environment, then
 $ sudo apt-get install git ruby autoconf bison gcc make zlib1g-dev libffi-dev libreadline-dev libgdbm-dev libssl-dev libyaml-dev
 ```
 
-If you would like to install other than `apt-get`, please refer to [Home · rbenv/ruby\-build Wiki](https://github.com/rbenv/ruby-build/wiki)
+If you would like to install other than `apt-get`, see for example [Home · rbenv/ruby\-build Wiki](https://github.com/rbenv/ruby-build/wiki)
 ## Exercise: Clone the MRI source code
 
 Use the following commands:

--- a/JA/2_mri_structure.md
+++ b/JA/2_mri_structure.md
@@ -33,7 +33,7 @@ git、ruby、autoconf、bison、gcc (or clang, etc）、make が必須です。�
 $ sudo apt-get install git ruby autoconf bison gcc make zlib1g-dev libffi-dev libreadline-dev libgdbm-dev libssl-dev libyaml-dev
 ```
 
-`apt-get` 以外でインストールしたい場合は、[Home · rbenv/ruby\-build Wiki](https://github.com/rbenv/ruby-build/wiki) を参照してみてください。
+`apt-get` 以外でインストールしたい場合は、例えば [Home · rbenv/ruby\-build Wiki](https://github.com/rbenv/ruby-build/wiki) を参照してみてください。
 
 ## 演習: MRI のソースコードを clone
 

--- a/JA/2_mri_structure.md
+++ b/JA/2_mri_structure.md
@@ -33,6 +33,8 @@ git、ruby、autoconf、bison、gcc (or clang, etc）、make が必須です。�
 $ sudo apt-get install git ruby autoconf bison gcc make zlib1g-dev libffi-dev libreadline-dev libgdbm-dev libssl-dev libyaml-dev
 ```
 
+`apt-get` 以外でインストールしたい場合は、[Home · rbenv/ruby\-build Wiki](https://github.com/rbenv/ruby-build/wiki) を参照してみてください。
+
 ## 演習: MRI のソースコードを clone
 
 1. `$ mkdir workdir`


### PR DESCRIPTION
The documentation only describes apt-get instructions, but most people who build environments on Macs use homebrew. We would like to place [Home · rbenv/ruby\-build Wiki](https://github.com/rbenv/ruby-build/wiki) where they can browse other procedures to help them build their environment smoothly.