### PR TITLE
Update links to wiki

### DIFF
--- a/EN/1_culture.md
+++ b/EN/1_culture.md
@@ -60,8 +60,8 @@ Good bug reports should contain the following:
 * Actual behaviour exhibited.
 * A patch which solves the issue (if possible).
 
-For details, please check <https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport> (English)
-or Japanese version <https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReportJ>.
+For details, please check <https://github.com/ruby/ruby/wiki/How-To-Report> (English)
+or Japanese version <https://github.com/ruby/ruby/wiki/How-To-Report-JA>.
 
 Good feature request should contain the following:
 
@@ -76,7 +76,7 @@ Good feature request should contain the following:
 For example, if you submit a "Feature request", then you will certainly be asked "what are your actual use cases?"
 This is an extreme example: if you proposed that "this feature should be changed because of inconsistency, but I don't use this feature any more", then your proposal will be rejected (fixing inconsistency is not more important than compatibility).
 
-For further information, please check <https://bugs.ruby-lang.org/projects/ruby/wiki/HowToRequestFeatures>.
+For further information, please check <https://github.com/ruby/ruby/wiki/How-To-Request-Features>.
 
 Issues or Pull Requests on GitHub are checked occasionally. In other words, sometimes they are ignored.
 I recommend you to make a new ticket on Redmine and link to your Issue or Pull Request on GitHub.

--- a/JA/1_culture.md
+++ b/JA/1_culture.md
@@ -88,7 +88,7 @@ Ruby が利用している Redmine では、チケットを登録する際、チ
 * 実際に得られた挙動
 * （可能なら）その問題を修正するためのパッチ
 
-詳細は、英語 <https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReport> (English) もしくは日本語 <https://bugs.ruby-lang.org/projects/ruby/wiki/HowToReportJa> のドキュメントがありますのでご参照ください。
+詳細は、英語 <https://github.com/ruby/ruby/wiki/How-To-Report> (English) もしくは日本語 <https://github.com/ruby/ruby/wiki/How-To-Report-Ja> のドキュメントがありますのでご参照ください。
 
 良い Feature request （機能追加要求）には、次のような内容が含まれていることが期待されます。
 
@@ -102,7 +102,7 @@ Ruby が利用している Redmine では、チケットを登録する際、チ
 
 機能追加要求では「実際にどんなユースケースがあるのか」という点が（最近だととくに）よく求められます。例えば、「使わないけど、整合性のためにはこういう機能があるほうがいいのではないか」という提案は、あまり通らないことが多いです（この場合、整合性よりも互換性のほうが優先されます）。
 
-さらなる詳細は <https://bugs.ruby-lang.org/projects/ruby/wiki/HowToRequestFeatures> （英語）をご参照ください。
+さらなる詳細は <https://github.com/ruby/ruby/wiki/How-To-Request-Features> （英語）をご参照ください。
 
 GitHub への issue および Pull request は運が良ければ対応されますが、運が悪ければ放置されます。それらを作成した場合、Redmine への issue を別途作成し、Github の当該 URL を示す、というのが良いと思います（もしくは、誰かコミッタに連絡すれば、対応してくれるかもしれません）。
 

--- a/bib.md
+++ b/bib.md
@@ -3,8 +3,8 @@
 ## English
 
 * Redmine wiki
-    * https://bugs.ruby-lang.org/projects/ruby/wiki
-    * https://bugs.ruby-lang.org/projects/ruby/wiki/DeveloperHowto
+    * https://github.com/ruby/ruby/wiki
+    * https://github.com/ruby/ruby/wiki/Developer-How-To
 * [Ruby Hacking Guide](https://ruby-hacking-guide.github.io/) by @minero-aoki
   * MRI Internal complete guide for Ruby 1.8 era.
   * Part 1, 2 (GC, Parser) are valuable yet.
@@ -16,8 +16,8 @@
 ## Japanese
 
 * Redmine wiki
-   * https://bugs.ruby-lang.org/projects/ruby/wiki
-   * https://bugs.ruby-lang.org/projects/ruby/wiki/DeveloperHowto
+   * https://github.com/ruby/ruby/wiki
+   * https://github.com/ruby/ruby/wiki/Developer-How-To
 * [Rubyの拡張ライブラリの作り方](https://docs.ruby-lang.org/en/2.4.0/extension_ja_rdoc.html)
    * Ruby (MRI) の拡張ライブラリの作り方と、詳細な API の情報がまとまっています。
 * [Ruby Hacking Guide](http://i.loveruby.net/ja/rhg/) by @minero-aoki


### PR DESCRIPTION
As the wiki is now located at https://github.com/ruby/ruby/wiki/